### PR TITLE
Build Docker Image and Publish to Dockerhub

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,7 +24,7 @@ jobs:
       # In case we run a pull request, the secrets are not available to us. Therefore check first
       # and assign a 'dummy' dockerhub username
       DOCKERHUB_USERNAME: ${{ ( secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_USERNAME ) || 'dummy' }}
-      DOCKERHUB_TAG_SUFFIX: ${{ ( github.event.ref == 'refs/heads/development' && '-development' ) || ( github.event.ref == 'refs/heads/master' && '' ) || '-dummy' }}
+      DOCKERHUB_TAG_SUFFIX: ${{ ( github.event.ref == 'refs/heads/development' && format('{0}-{1}', matrix.platform, 'development') ) || ( github.event.ref == 'refs/heads/master' && matrix.platform ) || '-dummy' }}
     strategy:
       matrix:
         include:
@@ -56,4 +56,4 @@ jobs:
           file: docker/build/${{ matrix.platform }}/Dockerfile
           platforms: ${{ matrix.docker-platform }}
           push: ${{ env.DOCKERHUB_PUBLISH == 'true' }}
-          tags: ${{ env.DOCKERHUB_USERNAME }}/opendatacam-darknet-base:${{ matrix.platform }}${{ DOCKERHUB_TAG_SUFFIX }}
+          tags: ${{ env.DOCKERHUB_USERNAME }}/opendatacam-darknet-base:${{ env.DOCKERHUB_TAG_SUFFIX }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,58 @@
+name: CI/CD
+
+# Trigger the workflow on push or pull request
+# Run on all branches and pull request except gh-pages which has it's own action
+on:
+  push:
+    branches-ignore:
+      - 'gh-pages'
+  pull_request:
+    branches-ignore:
+      - 'gh-pages'
+
+jobs:
+  # Build docker images
+  #
+  # TODO: Publish docker images to dockerhub on changes in the development branch.
+  # We won't push major releases. But development previews are fine.
+  build-docker-and-publish:
+    runs-on: ubuntu-latest
+    # needs: build-and-test-code
+    env:
+      # Only publish to Docker Hub if we have a change in the development branch
+      DOCKERHUB_PUBLISH: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/development' && secrets.DOCKERHUB_USERNAME != '' }}
+      # In case we run a pull request, the secrets are not available to us. Therefore check first
+      # and assign a 'dummy' dockerhub username
+      DOCKERHUB_USERNAME: ${{ ( secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_USERNAME ) || 'dummy' }}
+    strategy:
+      matrix:
+        include:
+        - platform: desktop
+          docker-platform: linux/amd64
+        - platform: xavier
+          docker-platform: linux/arm64
+        - platform: nano
+          docker-platform: linux/arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_PUBLISH == 'true' }}
+        continue-on-error: true
+        uses: docker/login-action@v1
+        with:
+          # Use the secrets directly and not the validated environment DOCKERHUB_USERNAME
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: docker/build/${{ matrix.platform }}/Dockerfile
+          platforms: ${{ matrix.docker-platform }}
+          push: ${{ env.DOCKERHUB_PUBLISH == 'true' }}
+          tags: ${{ env.DOCKERHUB_USERNAME }}/opendatacam-darknet-base:development-${{ matrix.platform }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,10 +20,11 @@ jobs:
     # needs: build-and-test-code
     env:
       # Only publish to Docker Hub if we have a change in the development branch
-      DOCKERHUB_PUBLISH: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/development' && secrets.DOCKERHUB_USERNAME != '' }}
+      DOCKERHUB_PUBLISH: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/development' || github.event.ref == 'refs/heads/master') && secrets.DOCKERHUB_USERNAME != '' }}
       # In case we run a pull request, the secrets are not available to us. Therefore check first
       # and assign a 'dummy' dockerhub username
       DOCKERHUB_USERNAME: ${{ ( secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_USERNAME ) || 'dummy' }}
+      DOCKERHUB_TAG_SUFFIX: ${{ ( github.event.ref == 'refs/heads/development' && '-development' ) || ( github.event.ref == 'refs/heads/master' && '' ) || '-dummy' }}
     strategy:
       matrix:
         include:
@@ -55,4 +56,4 @@ jobs:
           file: docker/build/${{ matrix.platform }}/Dockerfile
           platforms: ${{ matrix.docker-platform }}
           push: ${{ env.DOCKERHUB_PUBLISH == 'true' }}
-          tags: ${{ env.DOCKERHUB_USERNAME }}/opendatacam-darknet-base:development-${{ matrix.platform }}
+          tags: ${{ env.DOCKERHUB_USERNAME }}/opendatacam-darknet-base:${{ matrix.platform }}${{ DOCKERHUB_TAG_SUFFIX }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,7 +24,7 @@ jobs:
       # In case we run a pull request, the secrets are not available to us. Therefore check first
       # and assign a 'dummy' dockerhub username
       DOCKERHUB_USERNAME: ${{ ( secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_USERNAME ) || 'dummy' }}
-      DOCKERHUB_TAG_SUFFIX: ${{ ( github.event.ref == 'refs/heads/development' && format('{0}-{1}', matrix.platform, 'development') ) || ( github.event.ref == 'refs/heads/master' && matrix.platform ) || '-dummy' }}
+      DOCKERHUB_TAG_SUFFIX: ${{ ( github.event.ref == 'refs/heads/development' && format('{0}-{1}', matrix.platform, 'development') ) || ( github.event.ref == 'refs/heads/master' && matrix.platform ) || format('{0}-{1}', matrix.platform, 'dummy') }}
     strategy:
       matrix:
         include:

--- a/docker/build/desktop/Dockerfile
+++ b/docker/build/desktop/Dockerfile
@@ -1,0 +1,16 @@
+FROM opendatacam/base-desktop-nvidia-cuda-opencv-gstreamer:1.0
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y jq wget
+
+# Start Darknet Install
+RUN git clone --depth 1 -b odc https://github.com/opendatacam/darknet /var/local/darknet
+
+WORKDIR /var/local/darknet
+
+RUN sed -i -e s/GPU=0/GPU=1/ Makefile;
+RUN sed -i -e s/CUDNN=0/CUDNN=1/ Makefile;
+RUN sed -i -e s/OPENCV=0/OPENCV=1/ Makefile;
+
+RUN make

--- a/docker/build/nano/Dockerfile
+++ b/docker/build/nano/Dockerfile
@@ -1,0 +1,15 @@
+FROM resinplayground/jetson-nano-cuda-cudnn-opencv:v0.2-slim
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y jq wget
+
+# Start Darknet Install
+RUN git clone --depth 1 -b odc https://github.com/opendatacam/darknet /var/local/darknet
+
+WORKDIR /var/local/darknet
+
+# COPY Makefile
+COPY docker/build/nano/Makefile Makefile
+
+RUN make

--- a/docker/build/nano/Makefile
+++ b/docker/build/nano/Makefile
@@ -1,0 +1,182 @@
+GPU=1
+CUDNN=1
+CUDNN_HALF=0
+OPENCV=1
+AVX=0
+OPENMP=0
+LIBSO=0
+ZED_CAMERA=0 # ZED SDK 3.0 and above
+ZED_CAMERA_v2_8=0 # ZED SDK 2.X
+
+# set GPU=1 and CUDNN=1 to speedup on GPU
+# set CUDNN_HALF=1 to further speedup 3 x times (Mixed-precision on Tensor Cores) GPU: Volta, Xavier, Turing and higher
+# set AVX=1 and OPENMP=1 to speedup on CPU (if error occurs then set AVX=0)
+
+USE_CPP=0
+DEBUG=0
+
+# ARCH= -gencode arch=compute_30,code=sm_30 \
+#       -gencode arch=compute_35,code=sm_35 \
+#       -gencode arch=compute_50,code=[sm_50,compute_50] \
+#       -gencode arch=compute_52,code=[sm_52,compute_52] \
+# 	    -gencode arch=compute_61,code=[sm_61,compute_61]
+
+OS := $(shell uname)
+
+# Tesla V100
+# ARCH= -gencode arch=compute_70,code=[sm_70,compute_70]
+
+# GeForce RTX 2080 Ti, RTX 2080, RTX 2070, Quadro RTX 8000, Quadro RTX 6000, Quadro RTX 5000, Tesla T4, XNOR Tensor Cores
+# ARCH= -gencode arch=compute_75,code=[sm_75,compute_75]
+
+# Jetson XAVIER
+# ARCH= -gencode arch=compute_72,code=[sm_72,compute_72]
+
+# GTX 1080, GTX 1070, GTX 1060, GTX 1050, GTX 1030, Titan Xp, Tesla P40, Tesla P4
+# ARCH= -gencode arch=compute_61,code=sm_61 -gencode arch=compute_61,code=compute_61
+
+# GP100/Tesla P100 - DGX-1
+# ARCH= -gencode arch=compute_60,code=sm_60
+
+# For Jetson TX1, Tegra X1, DRIVE CX, DRIVE PX - uncomment:
+ARCH= -gencode arch=compute_53,code=[sm_53,compute_53]
+
+# For Jetson Tx2 or Drive-PX2 uncomment:
+# ARCH= -gencode arch=compute_62,code=[sm_62,compute_62]
+
+
+VPATH=./src/
+EXEC=darknet
+OBJDIR=./obj/
+
+ifeq ($(LIBSO), 1)
+LIBNAMESO=libdarknet.so
+APPNAMESO=uselib
+endif
+
+ifeq ($(USE_CPP), 1)
+CC=g++
+else
+CC=gcc
+endif
+
+CPP=g++ -std=c++11
+NVCC=/usr/local/cuda-10.0/bin/nvcc
+OPTS=-Ofast
+LDFLAGS= -lm -pthread
+COMMON= -Iinclude/ -I3rdparty/stb/include
+CFLAGS=-Wall -Wfatal-errors -Wno-unused-result -Wno-unknown-pragmas -fPIC
+
+ifeq ($(DEBUG), 1)
+#OPTS= -O0 -g
+#OPTS= -Og -g
+COMMON+= -DDEBUG
+CFLAGS+= -DDEBUG
+else
+ifeq ($(AVX), 1)
+CFLAGS+= -ffp-contract=fast -mavx -mavx2 -msse3 -msse4.1 -msse4.2 -msse4a
+endif
+endif
+
+CFLAGS+=$(OPTS)
+
+ifneq (,$(findstring MSYS_NT,$(OS)))
+LDFLAGS+=-lws2_32
+endif
+
+ifeq ($(OPENCV), 1)
+COMMON+= -DOPENCV
+CFLAGS+= -DOPENCV
+LDFLAGS+= `pkg-config --libs opencv4 2> /dev/null || pkg-config --libs opencv`
+COMMON+= `pkg-config --cflags opencv4 2> /dev/null || pkg-config --cflags opencv`
+endif
+
+ifeq ($(OPENMP), 1)
+CFLAGS+= -fopenmp
+LDFLAGS+= -lgomp
+endif
+
+ifeq ($(GPU), 1)
+COMMON+= -DGPU -I/usr/local/cuda-10.0/include/
+CFLAGS+= -DGPU
+ifeq ($(OS),Darwin) #MAC
+LDFLAGS+= -L/usr/local/cuda-10.0/lib -lcuda -lcudart -lcublas -lcurand
+else
+LDFLAGS+= -L/usr/local/cuda-10.0/lib64 -lcuda -lcudart -lcublas -lcurand
+endif
+endif
+
+ifeq ($(CUDNN), 1)
+COMMON+= -DCUDNN
+ifeq ($(OS),Darwin) #MAC
+CFLAGS+= -DCUDNN -I/usr/local/cuda-10.0/include
+LDFLAGS+= -L/usr/local/cuda-10.0/lib -lcudnn
+else
+CFLAGS+= -DCUDNN -I/usr/local/cuda-10.0/include
+LDFLAGS+= -L/usr/local/cuda-10.0/lib64 -lcudnn
+endif
+endif
+
+ifeq ($(CUDNN_HALF), 1)
+COMMON+= -DCUDNN_HALF
+CFLAGS+= -DCUDNN_HALF
+ARCH+= -gencode arch=compute_70,code=[sm_70,compute_70]
+endif
+
+ifeq ($(ZED_CAMERA), 1)
+CFLAGS+= -DZED_STEREO -I/usr/local/zed/include
+ifeq ($(ZED_CAMERA_v2_8), 1)
+LDFLAGS+= -L/usr/local/zed/lib -lsl_core -lsl_input -lsl_zed
+#-lstdc++ -D_GLIBCXX_USE_CXX11_ABI=0
+else
+LDFLAGS+= -L/usr/local/zed/lib -lsl_zed
+#-lstdc++ -D_GLIBCXX_USE_CXX11_ABI=0
+endif
+endif
+
+OBJ=image_opencv.o http_stream.o gemm.o utils.o dark_cuda.o convolutional_layer.o list.o image.o activations.o im2col.o col2im.o blas.o crop_layer.o dropout_layer.o maxpool_layer.o softmax_layer.o data.o matrix.o network.o connected_layer.o cost_layer.o parser.o option_list.o darknet.o detection_layer.o captcha.o route_layer.o writing.o box.o nightmare.o normalization_layer.o avgpool_layer.o coco.o dice.o yolo.o detector.o layer.o compare.o classifier.o local_layer.o swag.o shortcut_layer.o activation_layer.o rnn_layer.o gru_layer.o rnn.o rnn_vid.o crnn_layer.o demo.o tag.o cifar.o go.o batchnorm_layer.o art.o region_layer.o reorg_layer.o reorg_old_layer.o super.o voxel.o tree.o yolo_layer.o gaussian_yolo_layer.o upsample_layer.o lstm_layer.o conv_lstm_layer.o scale_channels_layer.o sam_layer.o
+ifeq ($(GPU), 1)
+LDFLAGS+= -lstdc++
+OBJ+=convolutional_kernels.o activation_kernels.o im2col_kernels.o col2im_kernels.o blas_kernels.o crop_layer_kernels.o dropout_layer_kernels.o maxpool_layer_kernels.o network_kernels.o avgpool_layer_kernels.o
+endif
+
+OBJS = $(addprefix $(OBJDIR), $(OBJ))
+DEPS = $(wildcard src/*.h) Makefile include/darknet.h
+
+all: $(OBJDIR) backup results setchmod $(EXEC) $(LIBNAMESO) $(APPNAMESO)
+
+ifeq ($(LIBSO), 1)
+CFLAGS+= -fPIC
+
+$(LIBNAMESO): $(OBJDIR) $(OBJS) include/yolo_v2_class.hpp src/yolo_v2_class.cpp
+	$(CPP) -shared -std=c++11 -fvisibility=hidden -DLIB_EXPORTS $(COMMON) $(CFLAGS) $(OBJS) src/yolo_v2_class.cpp -o $@ $(LDFLAGS)
+
+$(APPNAMESO): $(LIBNAMESO) include/yolo_v2_class.hpp src/yolo_console_dll.cpp
+	$(CPP) -std=c++11 $(COMMON) $(CFLAGS) -o $@ src/yolo_console_dll.cpp $(LDFLAGS) -L ./ -l:$(LIBNAMESO)
+endif
+
+$(EXEC): $(OBJS)
+	$(CPP) -std=c++11 $(COMMON) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+$(OBJDIR)%.o: %.c $(DEPS)
+	$(CC) $(COMMON) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR)%.o: %.cpp $(DEPS)
+	$(CPP) -std=c++11 $(COMMON) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR)%.o: %.cu $(DEPS)
+	$(NVCC) $(ARCH) $(COMMON) --compiler-options "$(CFLAGS)" -c $< -o $@
+
+$(OBJDIR):
+	mkdir -p $(OBJDIR)
+backup:
+	mkdir -p backup
+results:
+	mkdir -p results
+setchmod:
+	chmod +x *.sh
+
+.PHONY: clean
+
+clean:
+	rm -rf $(OBJS) $(EXEC) $(LIBNAMESO) $(APPNAMESO)

--- a/docker/build/xavier/Dockerfile
+++ b/docker/build/xavier/Dockerfile
@@ -1,0 +1,15 @@
+FROM resinplayground/jetson-nano-cuda-cudnn-opencv:v0.2-slim
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y jq wget
+
+# Start Darknet Install
+RUN git clone --depth 1 -b odc https://github.com/opendatacam/darknet /var/local/darknet
+
+WORKDIR /var/local/darknet
+
+# COPY Makefile
+COPY docker/build/xavier/Makefile Makefile
+
+RUN make

--- a/docker/build/xavier/Makefile
+++ b/docker/build/xavier/Makefile
@@ -1,0 +1,182 @@
+GPU=1
+CUDNN=1
+CUDNN_HALF=1
+OPENCV=1
+AVX=0
+OPENMP=0
+LIBSO=0
+ZED_CAMERA=0 # ZED SDK 3.0 and above
+ZED_CAMERA_v2_8=0 # ZED SDK 2.X
+
+# set GPU=1 and CUDNN=1 to speedup on GPU
+# set CUDNN_HALF=1 to further speedup 3 x times (Mixed-precision on Tensor Cores) GPU: Volta, Xavier, Turing and higher
+# set AVX=1 and OPENMP=1 to speedup on CPU (if error occurs then set AVX=0)
+
+USE_CPP=0
+DEBUG=0
+
+# ARCH= -gencode arch=compute_30,code=sm_30 \
+#       -gencode arch=compute_35,code=sm_35 \
+#       -gencode arch=compute_50,code=[sm_50,compute_50] \
+#       -gencode arch=compute_52,code=[sm_52,compute_52] \
+# 	    -gencode arch=compute_61,code=[sm_61,compute_61]
+
+OS := $(shell uname)
+
+# Tesla V100
+# ARCH= -gencode arch=compute_70,code=[sm_70,compute_70]
+
+# GeForce RTX 2080 Ti, RTX 2080, RTX 2070, Quadro RTX 8000, Quadro RTX 6000, Quadro RTX 5000, Tesla T4, XNOR Tensor Cores
+# ARCH= -gencode arch=compute_75,code=[sm_75,compute_75]
+
+# Jetson XAVIER
+ARCH= -gencode arch=compute_72,code=[sm_72,compute_72]
+
+# GTX 1080, GTX 1070, GTX 1060, GTX 1050, GTX 1030, Titan Xp, Tesla P40, Tesla P4
+# ARCH= -gencode arch=compute_61,code=sm_61 -gencode arch=compute_61,code=compute_61
+
+# GP100/Tesla P100 - DGX-1
+# ARCH= -gencode arch=compute_60,code=sm_60
+
+# For Jetson TX1, Tegra X1, DRIVE CX, DRIVE PX - uncomment:
+#ARCH= -gencode arch=compute_53,code=[sm_53,compute_53]
+
+# For Jetson Tx2 or Drive-PX2 uncomment:
+# ARCH= -gencode arch=compute_62,code=[sm_62,compute_62]
+
+
+VPATH=./src/
+EXEC=darknet
+OBJDIR=./obj/
+
+ifeq ($(LIBSO), 1)
+LIBNAMESO=libdarknet.so
+APPNAMESO=uselib
+endif
+
+ifeq ($(USE_CPP), 1)
+CC=g++
+else
+CC=gcc
+endif
+
+CPP=g++ -std=c++11
+NVCC=/usr/local/cuda-10.0/bin/nvcc
+OPTS=-Ofast
+LDFLAGS= -lm -pthread
+COMMON= -Iinclude/ -I3rdparty/stb/include
+CFLAGS=-Wall -Wfatal-errors -Wno-unused-result -Wno-unknown-pragmas -fPIC
+
+ifeq ($(DEBUG), 1)
+#OPTS= -O0 -g
+#OPTS= -Og -g
+COMMON+= -DDEBUG
+CFLAGS+= -DDEBUG
+else
+ifeq ($(AVX), 1)
+CFLAGS+= -ffp-contract=fast -mavx -mavx2 -msse3 -msse4.1 -msse4.2 -msse4a
+endif
+endif
+
+CFLAGS+=$(OPTS)
+
+ifneq (,$(findstring MSYS_NT,$(OS)))
+LDFLAGS+=-lws2_32
+endif
+
+ifeq ($(OPENCV), 1)
+COMMON+= -DOPENCV
+CFLAGS+= -DOPENCV
+LDFLAGS+= `pkg-config --libs opencv4 2> /dev/null || pkg-config --libs opencv`
+COMMON+= `pkg-config --cflags opencv4 2> /dev/null || pkg-config --cflags opencv`
+endif
+
+ifeq ($(OPENMP), 1)
+CFLAGS+= -fopenmp
+LDFLAGS+= -lgomp
+endif
+
+ifeq ($(GPU), 1)
+COMMON+= -DGPU -I/usr/local/cuda-10.0/include/
+CFLAGS+= -DGPU
+ifeq ($(OS),Darwin) #MAC
+LDFLAGS+= -L/usr/local/cuda-10.0/lib -lcuda -lcudart -lcublas -lcurand
+else
+LDFLAGS+= -L/usr/local/cuda-10.0/lib64 -lcuda -lcudart -lcublas -lcurand
+endif
+endif
+
+ifeq ($(CUDNN), 1)
+COMMON+= -DCUDNN
+ifeq ($(OS),Darwin) #MAC
+CFLAGS+= -DCUDNN -I/usr/local/cuda-10.0/include
+LDFLAGS+= -L/usr/local/cuda-10.0/lib -lcudnn
+else
+CFLAGS+= -DCUDNN -I/usr/local/cuda-10.0/include
+LDFLAGS+= -L/usr/local/cuda-10.0/lib64 -lcudnn
+endif
+endif
+
+ifeq ($(CUDNN_HALF), 1)
+COMMON+= -DCUDNN_HALF
+CFLAGS+= -DCUDNN_HALF
+ARCH+= -gencode arch=compute_70,code=[sm_70,compute_70]
+endif
+
+ifeq ($(ZED_CAMERA), 1)
+CFLAGS+= -DZED_STEREO -I/usr/local/zed/include
+ifeq ($(ZED_CAMERA_v2_8), 1)
+LDFLAGS+= -L/usr/local/zed/lib -lsl_core -lsl_input -lsl_zed
+#-lstdc++ -D_GLIBCXX_USE_CXX11_ABI=0
+else
+LDFLAGS+= -L/usr/local/zed/lib -lsl_zed
+#-lstdc++ -D_GLIBCXX_USE_CXX11_ABI=0
+endif
+endif
+
+OBJ=image_opencv.o http_stream.o gemm.o utils.o dark_cuda.o convolutional_layer.o list.o image.o activations.o im2col.o col2im.o blas.o crop_layer.o dropout_layer.o maxpool_layer.o softmax_layer.o data.o matrix.o network.o connected_layer.o cost_layer.o parser.o option_list.o darknet.o detection_layer.o captcha.o route_layer.o writing.o box.o nightmare.o normalization_layer.o avgpool_layer.o coco.o dice.o yolo.o detector.o layer.o compare.o classifier.o local_layer.o swag.o shortcut_layer.o activation_layer.o rnn_layer.o gru_layer.o rnn.o rnn_vid.o crnn_layer.o demo.o tag.o cifar.o go.o batchnorm_layer.o art.o region_layer.o reorg_layer.o reorg_old_layer.o super.o voxel.o tree.o yolo_layer.o gaussian_yolo_layer.o upsample_layer.o lstm_layer.o conv_lstm_layer.o scale_channels_layer.o sam_layer.o
+ifeq ($(GPU), 1)
+LDFLAGS+= -lstdc++
+OBJ+=convolutional_kernels.o activation_kernels.o im2col_kernels.o col2im_kernels.o blas_kernels.o crop_layer_kernels.o dropout_layer_kernels.o maxpool_layer_kernels.o network_kernels.o avgpool_layer_kernels.o
+endif
+
+OBJS = $(addprefix $(OBJDIR), $(OBJ))
+DEPS = $(wildcard src/*.h) Makefile include/darknet.h
+
+all: $(OBJDIR) backup results setchmod $(EXEC) $(LIBNAMESO) $(APPNAMESO)
+
+ifeq ($(LIBSO), 1)
+CFLAGS+= -fPIC
+
+$(LIBNAMESO): $(OBJDIR) $(OBJS) include/yolo_v2_class.hpp src/yolo_v2_class.cpp
+	$(CPP) -shared -std=c++11 -fvisibility=hidden -DLIB_EXPORTS $(COMMON) $(CFLAGS) $(OBJS) src/yolo_v2_class.cpp -o $@ $(LDFLAGS)
+
+$(APPNAMESO): $(LIBNAMESO) include/yolo_v2_class.hpp src/yolo_console_dll.cpp
+	$(CPP) -std=c++11 $(COMMON) $(CFLAGS) -o $@ src/yolo_console_dll.cpp $(LDFLAGS) -L ./ -l:$(LIBNAMESO)
+endif
+
+$(EXEC): $(OBJS)
+	$(CPP) -std=c++11 $(COMMON) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+$(OBJDIR)%.o: %.c $(DEPS)
+	$(CC) $(COMMON) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR)%.o: %.cpp $(DEPS)
+	$(CPP) -std=c++11 $(COMMON) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR)%.o: %.cu $(DEPS)
+	$(NVCC) $(ARCH) $(COMMON) --compiler-options "$(CFLAGS)" -c $< -o $@
+
+$(OBJDIR):
+	mkdir -p $(OBJDIR)
+backup:
+	mkdir -p backup
+results:
+	mkdir -p results
+setchmod:
+	chmod +x *.sh
+
+.PHONY: clean
+
+clean:
+	rm -rf $(OBJS) $(EXEC) $(LIBNAMESO) $(APPNAMESO)


### PR DESCRIPTION
Similar to the main Opendatacam repository this pull request enables an action that builds a `opendatacam-darknet-base` image for desktop, nano and xavier platforms and publishes it to DockerHub on pushes to the `master` and `development` branches.

See https://hub.docker.com/r/vsawdoteu/opendatacam-darknet-base for successfully published packages.

# Repository Changes

For the automatic publishing to work, actions must be enabled for the repository and the secrets to access dockerhub must be added. See https://github.com/opendatacam/opendatacam/pull/354#partial-pull-merging on how to prepare the repository.

Until the secrets are added to this repository, the pull request shall stay in "draft mode".

# See also

- https://github.com/opendatacam/opendatacam/issues/358