### PR TITLE
Fix: Stop using ::set-output in GitHub workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -43,11 +43,11 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_PUBLISH == 'true' }}
         continue-on-error: true
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           # Use the secrets directly and not the validated environment DOCKERHUB_USERNAME
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -64,7 +64,7 @@ jobs:
             echo "dockerhub-tag=development-${{ matrix.platform }}"  >> $GITHUB_OUTPUT
           fi
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./
           file: docker/build/${{ matrix.platform }}/Dockerfile

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,9 +59,9 @@ jobs:
         run: |
           GIT_TAG=$(git tag -l --points-at $(git log -n 1 --format=%H))
           if [ ! -z $GIT_TAG ]; then
-            echo "::set-output name=dockerhub-tag::$GIT_TAG-${{ matrix.platform }}"
+            echo "dockerhub-tag=$GIT_TAG-${{ matrix.platform }}"  >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=dockerhub-tag::development-${{ matrix.platform }}"
+            echo "dockerhub-tag=development-${{ matrix.platform }}"  >> $GITHUB_OUTPUT
           fi
       - name: Build and push
         uses: docker/build-push-action@v2


### PR DESCRIPTION
They will be deprecated by June 2023. See also
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/